### PR TITLE
Add Methode to invalidate layout of collection view, to allow resizing Screen

### DIFF
--- a/MultipleTabs/MultipleTabsViewController.swift
+++ b/MultipleTabs/MultipleTabsViewController.swift
@@ -374,6 +374,9 @@ extension MultipleTabsViewController: UICollectionViewDataSource, UICollectionVi
       currentIndex = newIndex
     }
   }
+  public func invalidateCollectionLayouts() {
+    collectionView.collectionViewLayout.invalidateLayout()
+  }
 }
 
 @objc public protocol MultipleTabsViewControllerDataSource {


### PR DESCRIPTION
For some case as iPad Resizing screen on multiple window, when we work on tabBar, outgoing to other controller resizing screen and coming back to our multipleTabs then collectionView didn't know screen was changed his dimension like this GIF.

so we need on our controller to call this helper new method in viewWilllayoutSubview to refresh lay outing.

I Creating a dummy application to demonstrate and explain our issue quickly.

With invalidateLayout:

![with-Invalidate480](https://user-images.githubusercontent.com/38799378/66466031-46717700-ea82-11e9-920c-68f3e658f17e.gif)

Without invalidateLayout:

![Without-invalidate](https://user-images.githubusercontent.com/38799378/66466159-83d60480-ea82-11e9-9d61-d201cc2950f0.gif)

